### PR TITLE
Introduce set of gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Ignore list for Eagle, a PCB layout tool
+
+# Backup files
+*.s#?
+*.b#?
+*.l#?
+
+
+# file locks introduced since 7.x
+*.lck
+
+
+# OS generated files #
+######################
+.DS_Store
+ehthumbs.db
+Icon?
+Thumbs.db
+*/overlays
+*~


### PR DESCRIPTION
Combined together
Eagle specific https://github.com/github/gitignore/blob/master/Eagle.gitignore
and OSX specific https://github.com/github/gitignore/blob/master/Global/OSX.gitignore

This change provide a solution for the issue then after cloning and opening some files in Eagle program we have a set of git untracked files. The "Best practices" in this case is to introduce set of gitignore rules.

I've removed a couple of rules from  Eagle.gitignore. If someone can review original list it would be great.
Also I've found a couple of odd files. 

./emonPi/emonPi_V1_5/readme.md~
./emonPi/emonPi_V1_6/readme.md~
./emonTH/emonTH_V1_5/readme.md~
./emonTxV3/emonTx_V3.2/readme.md~
./emonTxV3/emonTx_V3.4/readme.md~
./emonTxV3/readme.md~
./RFM2Pi/readme.md~

Shall I create PR to remove it?